### PR TITLE
Fix bug where can't add or remove samples

### DIFF
--- a/app/src/main/java/com/myvetpath/myvetpath/CreateSubActivity.java
+++ b/app/src/main/java/com/myvetpath/myvetpath/CreateSubActivity.java
@@ -159,12 +159,11 @@ db.addSubmission(sub)
                 newSickElement = dbHandler.findSickElementID(internalID);
                 samplesList = dbHandler.findSamples(internalID);
 
+                //Delete existing samples related to the submission in the database so that the user can add or remove samples.
                 for(Sample tempSample : samplesList){
                     dbHandler.deleteSample(internalID);
                 }
 
-                ArrayList<Sample> newSamplesList = dbHandler.findSamples(internalID);
-                
                 picturesList = dbHandler.findPictures(internalID);
                 updatingDraft = true;
                 draftName = newSub.getTitle();

--- a/app/src/main/java/com/myvetpath/myvetpath/CreateSubActivity.java
+++ b/app/src/main/java/com/myvetpath/myvetpath/CreateSubActivity.java
@@ -158,6 +158,13 @@ db.addSubmission(sub)
                 newSub = dbHandler.findSubmissionID(internalID);
                 newSickElement = dbHandler.findSickElementID(internalID);
                 samplesList = dbHandler.findSamples(internalID);
+
+                for(Sample tempSample : samplesList){
+                    dbHandler.deleteSample(internalID);
+                }
+
+                ArrayList<Sample> newSamplesList = dbHandler.findSamples(internalID);
+                
                 picturesList = dbHandler.findPictures(internalID);
                 updatingDraft = true;
                 draftName = newSub.getTitle();
@@ -223,7 +230,8 @@ db.addSubmission(sub)
                         dbHandler.updateSubmission(newSub);
                         dbHandler.updateSickElement(newSickElement);
                         for(Sample tempSample: samplesList){
-                            dbHandler.updateSample(tempSample);
+                            tempSample.setSamplelID(newSub.getInternalID());
+                            dbHandler.addSample(tempSample);
                         }
                         for(Picture tempPicture: picturesList){
                             dbHandler.updatePicture(tempPicture);

--- a/app/src/main/java/com/myvetpath/myvetpath/MyDBHandler.java
+++ b/app/src/main/java/com/myvetpath/myvetpath/MyDBHandler.java
@@ -310,6 +310,27 @@ public class MyDBHandler extends SQLiteOpenHelper {
         return result;
     }
 
+
+    //Deletes sample based on the ID
+    public boolean deleteSample(int ID) {
+        boolean result = false;
+        String query = "Select * FROM " + Sample.TABLE_NAME + " WHERE " + Sample.COLUMN_INTERNAL + " = '" + String.valueOf(ID) + "'";
+        SQLiteDatabase db = this.getWritableDatabase();
+        Cursor cursor = db.rawQuery(query, null);
+        Sample tempSample = new Sample();
+        if (cursor.moveToFirst()) {
+            tempSample.setSamplelID(Integer.parseInt(cursor.getString(cursor.getColumnIndex(Sample.COLUMN_ID))));
+            db.delete(Sample.TABLE_NAME, Sample.COLUMN_ID + "=?",
+                    new String[] {
+                            String.valueOf(tempSample.getInternalID())
+                    });
+            result = true;
+        }
+        cursor.close();
+        db.close();
+        return result;
+    }
+
     public boolean deletePicutre(int ID, String imageName) {
         boolean result = false;
         String query = "Select * FROM " + imageName + " WHERE " + Picture.COLUMN_ID + " = '" + String.valueOf(ID) + "'";


### PR DESCRIPTION
There was an issue where if you created a draft and then tried to edit that draft later, the app wouldn't save any new changes to the list of samples (either adding new ones or removing old ones). There was an issue with "updateSample()", and updateSample wouldn't account for cases when samples were removed. To fix this, the app now removes all existing samples related to the draft when the screen first opens and then adds the samples to the database when the user saves or submits the draft. I'm not sure if there was a better way.